### PR TITLE
Removed the unused MultiplayerSpawner from level.tscn

### DIFF
--- a/level/scenes/level.tscn
+++ b/level/scenes/level.tscn
@@ -334,10 +334,6 @@ horizontal_alignment = 1
 vertical_alignment = 1
 uppercase = true
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="."]
-_spawnable_scenes = PackedStringArray("uid://cffjduipbb3s5")
-spawn_path = NodePath("../PlayersContainer")
-
 [node name="PlayersContainer" type="Node3D" parent="."]
 
 [node name="GameControls" type="Control" parent="."]


### PR DESCRIPTION
This PR closes issue #10 by removing the unused MultiplayerSpawner from the scene tree in level.tscn.